### PR TITLE
Fix handling ApiRequestException when sending a request.  

### DIFF
--- a/TelegramBotBase/BotBase.cs
+++ b/TelegramBotBase/BotBase.cs
@@ -72,6 +72,7 @@ namespace TelegramBotBase
         {
             this.SystemSettings = new Dictionary<eSettings, uint>();
 
+            SetSetting(eSettings.MaxNumberOfRetries, 5);
             SetSetting(eSettings.NavigationMaximum, 10);
             SetSetting(eSettings.LogAllMessages, false);
             SetSetting(eSettings.SkipAllMessages, false);
@@ -176,6 +177,8 @@ namespace TelegramBotBase
                     this.Sessions.SaveSessionStates();
                 });
             }
+
+            DeviceSession.MaxNumberOfRetries = this.GetSetting(eSettings.MaxNumberOfRetries, 5);
 
             this.Client.TelegramClient.StartReceiving();
         }

--- a/TelegramBotBase/Enums/eSettings.cs
+++ b/TelegramBotBase/Enums/eSettings.cs
@@ -27,9 +27,14 @@ namespace TelegramBotBase.Enums
         /// <summary>
         /// Does stick to the console event handler and saves all sessions on exit.
         /// </summary>
-        SaveSessionsOnConsoleExit = 4
+        SaveSessionsOnConsoleExit = 4,
 
 
+        /// <summary>
+        /// Indicates the maximum number of times a request that received error 
+        /// 429 will be sent again after a timeout until it receives code 200 or an error code not equal to 429.
+        /// </summary>
+        MaxNumberOfRetries = 5,
 
     }
 }

--- a/TelegramBotBase/Sessions/DeviceSession.cs
+++ b/TelegramBotBase/Sessions/DeviceSession.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -770,20 +770,24 @@ namespace TelegramBotBase.Sessions
         /// <returns></returns>
         public async Task<T> API<T>(Func<Telegram.Bot.TelegramBotClient, Task<T>> call)
         {
-            try
+            var numberOfTries = 0;
+            while (numberOfTries < DeviceSession.MaxNumberOfRetries)
             {
-                return await call(this.Client.TelegramClient);
-            }
-            catch (ApiRequestException ex)
-            {
-                if (ex.Parameters != null)
+                try
                 {
-                    await Task.Delay(ex.Parameters.RetryAfter);
+                    return await call(Client.TelegramClient);
+                }
+                catch (ApiRequestException ex)
+                {
+                    if (ex.ErrorCode != 429)
+                        throw;
 
-                    return await call(this.Client.TelegramClient);
+                    if (ex.Parameters != null)
+                        await Task.Delay(ex.Parameters.RetryAfter * 1000);
+
+                    numberOfTries++;
                 }
             }
-
             return default(T);
         }
 
@@ -794,17 +798,23 @@ namespace TelegramBotBase.Sessions
         /// <returns></returns>
         public async Task API(Func<Telegram.Bot.TelegramBotClient, Task> call)
         {
-            try
+            var numberOfTries = 0;
+            while (numberOfTries < DeviceSession.MaxNumberOfRetries)
             {
-                await call(this.Client.TelegramClient);
-            }
-            catch (ApiRequestException ex)
-            {
-                if (ex.Parameters != null)
+                try
                 {
-                    await Task.Delay(ex.Parameters.RetryAfter);
+                    await call(Client.TelegramClient);
+                    return;
+                }
+                catch (ApiRequestException ex)
+                {
+                    if (ex.ErrorCode != 429)
+                        throw;
 
-                    await call(this.Client.TelegramClient);
+                    if (ex.Parameters != null)
+                        await Task.Delay(ex.Parameters.RetryAfter * 1000);
+
+                    numberOfTries++;
                 }
             }
         }

--- a/TelegramBotBase/Sessions/DeviceSession.cs
+++ b/TelegramBotBase/Sessions/DeviceSession.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -876,5 +876,15 @@ namespace TelegramBotBase.Sessions
         }
 
         #endregion
+
+        #region "Static"
+
+        /// <summary>
+        /// Indicates the maximum number of times a request that received error 
+        /// 429 will be sent again after a timeout until it receives code 200 or an error code not equal to 429.
+        /// </summary>
+        public static uint MaxNumberOfRetries { get; set; }
+
+        #endregion "Static"
     }
 }


### PR DESCRIPTION
- Added new setting which indicates the maximum number of times a request that received error 429 will be sent again after a timeout until it receives code 200 or an error code not equal to 429.
- Change API method. Now calls occur in a loop, but a limited number of times. This also ensures that exceptions are caught during a repeated request