### PR TITLE
Updating to TelegramBotFramework 16.0.2

### DIFF
--- a/TelegramBotBase/Sessions/DeviceSession.cs
+++ b/TelegramBotBase/Sessions/DeviceSession.cs
@@ -700,7 +700,7 @@ namespace TelegramBotBase.Sessions
 
         #region "Users"
 
-        public virtual async Task RestrictUser(int userId, ChatPermissions permissions, DateTime until = default(DateTime))
+        public virtual async Task RestrictUser(long userId, ChatPermissions permissions, DateTime until = default(DateTime))
         {
             try
             {
@@ -712,7 +712,7 @@ namespace TelegramBotBase.Sessions
             }
         }
 
-        public virtual async Task<ChatMember> GetChatUser(int userId)
+        public virtual async Task<ChatMember> GetChatUser(long userId)
         {
             try
             {
@@ -725,7 +725,7 @@ namespace TelegramBotBase.Sessions
             return null;
         }
 
-        public virtual async Task KickUser(int userId, DateTime until = default(DateTime))
+        public virtual async Task KickUser(long userId, DateTime until = default(DateTime))
         {
             try
             {
@@ -737,7 +737,7 @@ namespace TelegramBotBase.Sessions
             }
         }
 
-        public virtual async Task UnbanUser(int userId)
+        public virtual async Task UnbanUser(long userId)
         {
             try
             {

--- a/TelegramBotBase/TelegramBotBase.csproj
+++ b/TelegramBotBase/TelegramBotBase.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net472;net5;netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -82,9 +82,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
-    <PackageReference Include="Telegram.Bot" Version="15.7.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.ComponentModel" Version="4.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+    <PackageReference Include="Telegram.Bot" Version="16.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TelegramBotBaseTest/Tests/Groups/LinkReplaceTest.cs
+++ b/TelegramBotBaseTest/Tests/Groups/LinkReplaceTest.cs
@@ -12,7 +12,7 @@ namespace TelegramBotBaseTest.Tests.Groups
     public class LinkReplaceTest : TelegramBotBase.Form.GroupForm
     {
 
-        Dictionary<int, int> Counter { get; set; } = new Dictionary<int, int>();
+        Dictionary<long, int> Counter { get; set; } = new Dictionary<long, int>();
 
         private const int Maximum = 3;
 


### PR DESCRIPTION
ATTENTION: UserIds will no longer be "int", instead it has to be of the "long" datatype
- updating DeviceSession methods for new datatype
- updating LinkReplaceTest class example
- adding .NET 5 as target framework