### PR TITLE
Call Serialize implicitly when assigning to a string

### DIFF
--- a/TelegramBotBase/Form/CallbackData.cs
+++ b/TelegramBotBase/Form/CallbackData.cs
@@ -77,6 +77,7 @@ namespace TelegramBotBase.Form
 
             return null;
         }
-
+        
+        public static implicit operator string(CallbackData callbackData) => callbackData.Serialize();
     }
 }


### PR DESCRIPTION
Every time a ButtonBase is instantiated and `CallbackData` get used as a Value for it, `.Serialize()` need to be called because Value only accept an string.

So with this instead of:
```csharp
var new button = new ButtonBase("Edit", new CallbackData("a", CallbackValues.Name).Serialize());
```

Now you can do:
```csharp
var new button = new ButtonBase("Edit", new CallbackData("a", CallbackValues.Name));
```

So no more `.Serialize()` call.