### PR TITLE
Add Web App Inline Keyboard Button

### DIFF
--- a/TelegramBotBase/Form/WebAppButtonBase.cs
+++ b/TelegramBotBase/Form/WebAppButtonBase.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace TelegramBotBase.Form
+{
+    public class WebAppButtonBase : ButtonBase
+    {
+        public WebAppInfo WebAppInfo { get; set; }
+
+        public WebAppButtonBase()
+        {
+
+        }
+
+        public WebAppButtonBase(String Text, WebAppInfo WebAppInfo)
+        {
+            this.Text = Text;
+            this.WebAppInfo = WebAppInfo;
+        }
+
+        /// <summary>
+        /// Returns an inline Button
+        /// </summary>
+        /// <param name="form"></param>
+        /// <returns></returns>
+        public override InlineKeyboardButton ToInlineButton(ButtonForm form)
+        {
+            return InlineKeyboardButton.WithWebApp(this.Text, this.WebAppInfo);
+        }
+
+
+        /// <summary>
+        /// Returns a KeyBoardButton
+        /// </summary>
+        /// <param name="form"></param>
+        /// <returns></returns>
+        public override KeyboardButton ToKeyboardButton(ButtonForm form)
+        {
+            return KeyboardButton.WithWebApp(this.Text, this.WebAppInfo);
+        }
+
+    }
+}


### PR DESCRIPTION
WebApp was recently launched in Telegram Bot. One of the scenarios is to open a web app from an inline keyboard button. 

This PR intends to add support for inline keyboard button with webapp option. 