### PR TITLE
Added the ReceiveError event to MessageClient to provide the ability to handle exceptions in client code

### DIFF
--- a/TelegramBotBase/Base/ErrorResult.cs
+++ b/TelegramBotBase/Base/ErrorResult.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace TelegramBotBase.Base
+{
+    public class ErrorResult : EventArgs
+    {
+        public ErrorResult(Exception exception)
+        {
+            Exception = exception;
+        }
+
+        public Exception Exception { get; }
+    }
+}

--- a/TelegramBotBase/Base/MessageClient.cs
+++ b/TelegramBotBase/Base/MessageClient.cs
@@ -199,18 +199,19 @@ public class MessageClient
         if (eventHandlers != null)
         {
             await eventHandlers;
+            return;
+        }
+
+        //Fallback when no event handler is used.
+        if (update.Exception is ApiRequestException exApi)
+        {
+            Console.WriteLine($"Telegram API Error:\n[{exApi.ErrorCode}]\n{exApi.Message}");
         }
         else
         {
-            if (update.Exception is ApiRequestException exApi)
-            {
-                Console.WriteLine($"Telegram API Error:\n[{exApi.ErrorCode}]\n{exApi.Message}");
-            }
-            else
-            {
-                Console.WriteLine(update.Exception.ToString());
-            }
+            Console.WriteLine(update.Exception.ToString());
         }
+
     }
 
     #endregion


### PR DESCRIPTION
Hello everyone!
I've found Console.WriteLine calls in code and this doesn't work for me, because I have structured json logging via Serilog and raw Console logging breaks my log scrapper. So i need a mechanism that will catch an exception and handle it the way i need.

I left the same behaviour as it was before for old clients, so it is not a breaking change at all.

Please accept the PR)