### PR TITLE
Fix: get chat id from edited message

### DIFF
--- a/TelegramBotBase/Base/UpdateResult.cs
+++ b/TelegramBotBase/Base/UpdateResult.cs
@@ -16,6 +16,7 @@ public class UpdateResult : ResultBase
     /// </summary>
     public override long DeviceId =>
         RawData?.Message?.Chat?.Id
+        ?? RawData?.EditedMessage?.Chat?.Id
         ?? RawData?.CallbackQuery?.Message?.Chat?.Id
         ?? Device?.DeviceId
         ?? 0;


### PR DESCRIPTION
Hello everyone,
I ran into an issue when using TelegramBorBase library: DeviceSession.DeviceId is always == 0 on a message edit event, resulting in incorrect session management.