### PR TITLE
Fix di navigation scope

### DIFF
--- a/TelegramBotBase/Base/FormBase.cs
+++ b/TelegramBotBase/Base/FormBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using TelegramBotBase.Args;
 using TelegramBotBase.Base;
 using TelegramBotBase.Form.Navigation;
@@ -40,7 +41,7 @@ public class FormBase : IDisposable
     /// </summary>
     public Telegram.Bot.ITelegramBotClient API => Client?.TelegramClient;
 
-    IServiceProvider _serviceProvider = null;
+    private IServiceScope _serviceScope = null;
 
     /// <summary>
     ///     has this formular already been disposed ?

--- a/TelegramBotBase/Base/FormBase.cs
+++ b/TelegramBotBase/Base/FormBase.cs
@@ -16,7 +16,7 @@ namespace TelegramBotBase.Form;
 /// <summary>
 ///     Base class for forms
 /// </summary>
-public class FormBase : IDisposable
+public class FormBase : IAsyncDisposable
 {
     private static readonly object EvInit = new();
 
@@ -64,7 +64,7 @@ public class FormBase : IDisposable
     /// <summary>
     ///     Cleanup
     /// </summary>
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         Client = null;
         Device = null;
@@ -464,5 +464,4 @@ public class FormBase : IDisposable
     /// Returns if this instance is a subclass of AutoCleanForm. Necessary to prevent message deletion if not necessary.
     /// </summary>
     public bool IsAutoCleanForm() => this.GetType().IsSubclassOf(typeof(AutoCleanForm));
-
 }

--- a/TelegramBotBase/Base/FormBase.cs
+++ b/TelegramBotBase/Base/FormBase.cs
@@ -69,27 +69,10 @@ public class FormBase : IAsyncDisposable
         Client = null;
         Device = null;
 
-        await DisposeDiEscort();
+        if (_diEscort != null) await _diEscort.DisposeAsync();
+        _diEscort = null;
         
         IsDisposed = true;
-    }
-
-    private async ValueTask DisposeDiEscort()
-    {
-        if (_diEscort == null) return;
-        
-        if (_diEscort.ServiceScope is IAsyncDisposable ad)
-        {
-            await ad.DisposeAsync();
-        }
-        else
-        {
-            _diEscort.ServiceScope.Dispose();
-        }
-
-        _diEscort.ServiceScope = null;
-        _diEscort.FormFactory = null;
-        _diEscort = null;
     }
 
 

--- a/TelegramBotBase/Base/FormBase.cs
+++ b/TelegramBotBase/Base/FormBase.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using TelegramBotBase.Args;
 using TelegramBotBase.Base;
+using TelegramBotBase.DependencyInjection;
 using TelegramBotBase.Form.Navigation;
 using TelegramBotBase.Interfaces;
 using static TelegramBotBase.Base.Async;
@@ -41,7 +42,7 @@ public class FormBase : IDisposable
     /// </summary>
     public Telegram.Bot.ITelegramBotClient API => Client?.TelegramClient;
 
-    private IServiceScope _serviceScope = null;
+    private FormDiEscort _diEscort = null;
 
     /// <summary>
     ///     has this formular already been disposed ?

--- a/TelegramBotBase/Base/FormBase.cs
+++ b/TelegramBotBase/Base/FormBase.cs
@@ -68,6 +68,9 @@ public class FormBase : IAsyncDisposable
     {
         Client = null;
         Device = null;
+
+        await DisposeDiEscort();
+        
         IsDisposed = true;
     }
 

--- a/TelegramBotBase/Base/FormBase.cs
+++ b/TelegramBotBase/Base/FormBase.cs
@@ -89,6 +89,7 @@ public class FormBase : IAsyncDisposable
 
         _diEscort.ServiceScope = null;
         _diEscort.FormFactory = null;
+        _diEscort = null;
     }
 
 

--- a/TelegramBotBase/Base/FormBase.cs
+++ b/TelegramBotBase/Base/FormBase.cs
@@ -144,15 +144,15 @@ public class FormBase : IAsyncDisposable
     public async Task OnClosed(EventArgs e)
     {
         var handler = Events[EvClosed]?.GetInvocationList().Cast<AsyncEventHandler<EventArgs>>();
-        if (handler == null)
+        if (handler != null)
         {
-            return;
+            foreach (var h in handler)
+            {
+                await h.InvokeAllAsync(this, e);
+            }
         }
 
-        foreach (var h in handler)
-        {
-            await h.InvokeAllAsync(this, e);
-        }
+        await DisposeAsync();
     }
 
 

--- a/TelegramBotBase/Base/FormBase.cs
+++ b/TelegramBotBase/Base/FormBase.cs
@@ -71,6 +71,23 @@ public class FormBase : IAsyncDisposable
         IsDisposed = true;
     }
 
+    private async ValueTask DisposeDiEscort()
+    {
+        if (_diEscort == null) return;
+        
+        if (_diEscort.ServiceScope is IAsyncDisposable ad)
+        {
+            await ad.DisposeAsync();
+        }
+        else
+        {
+            _diEscort.ServiceScope.Dispose();
+        }
+
+        _diEscort.ServiceScope = null;
+        _diEscort.FormFactory = null;
+    }
+
 
     public async Task OnInit(InitEventArgs e)
     {

--- a/TelegramBotBase/DependencyInjection/Extensions.cs
+++ b/TelegramBotBase/DependencyInjection/Extensions.cs
@@ -10,7 +10,7 @@ namespace TelegramBotBase.DependencyInjection
 {
     public static class Extensions
     {
-        internal static FieldInfo _ServiceProviderField = typeof(FormBase).GetField("_serviceProvider", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        internal static FieldInfo _ServiceScopeField = typeof(FormBase).GetField("_serviceScope", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 
         /// <summary>
         /// Use Dependency Injection to create new form and inject parameters. (Main variant)

--- a/TelegramBotBase/DependencyInjection/Extensions.cs
+++ b/TelegramBotBase/DependencyInjection/Extensions.cs
@@ -73,14 +73,14 @@ namespace TelegramBotBase.DependencyInjection
         }
 
         /// <summary>
-        /// Gets the internal service provider field value.
+        /// Gets the internal service scope field value.
         /// </summary>
         /// <param name="form"></param>
         /// <returns></returns>
-        public static IServiceProvider GetServiceProvider(this FormBase form)
+        public static IServiceScope GetServiceScope(this FormBase form)
         {
-            var sp = _ServiceProviderField?.GetValue(form) as IServiceProvider;
-            return sp;
+            var ss = _ServiceScopeField?.GetValue(form) as IServiceScope;
+            return ss;
         }
     }
 }

--- a/TelegramBotBase/DependencyInjection/Extensions.cs
+++ b/TelegramBotBase/DependencyInjection/Extensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using System;
+﻿using System;
 using System.Reflection;
 using System.Threading.Tasks;
 using TelegramBotBase.Form;

--- a/TelegramBotBase/DependencyInjection/Extensions.cs
+++ b/TelegramBotBase/DependencyInjection/Extensions.cs
@@ -10,7 +10,7 @@ namespace TelegramBotBase.DependencyInjection
 {
     public static class Extensions
     {
-        internal static FieldInfo _ServiceScopeField = typeof(FormBase).GetField("_serviceScope", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        internal static FieldInfo _DiEscortField = typeof(FormBase).GetField("_diEscort", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 
         /// <summary>
         /// Use Dependency Injection to create new form and inject parameters. (Main variant)
@@ -48,7 +48,7 @@ namespace TelegramBotBase.DependencyInjection
             if (!typeof(FormBase).IsAssignableFrom(formBaseType))
                 throw new ArgumentException($"{nameof(formBaseType)} argument must be a {nameof(FormBase)} type");
 
-            var _serviceProvider = current_form.GetServiceProvider();
+            var scope = current_form.GetServiceScope();
 
             var instance = ActivatorUtilities.CreateInstance(_serviceProvider, formBaseType) as FormBase;
 
@@ -63,23 +63,23 @@ namespace TelegramBotBase.DependencyInjection
         }
 
         /// <summary>
-        /// Sets the internal service scope field.
+        /// Sets the internal di escort field.
         /// </summary>
         /// <param name="form"></param>
-        /// <param name="serviceScope"></param>
-        public static void SetServiceScope(this FormBase form, IServiceScope serviceScope)
+        /// <param name="diEscort"></param>
+        public static void SetDiEscort(this FormBase form, FormDiEscort diEscort)
         {
-            _ServiceScopeField?.SetValue(form, serviceScope);
+            _DiEscortField?.SetValue(form, diEscort);
         }
 
         /// <summary>
-        /// Gets the internal service scope field value.
+        /// Gets the internal di escort field value.
         /// </summary>
         /// <param name="form"></param>
         /// <returns></returns>
-        public static IServiceScope GetServiceScope(this FormBase form)
+        public static FormDiEscort GetDiEscort(this FormBase form)
         {
-            var ss = _ServiceScopeField?.GetValue(form) as IServiceScope;
+            var ss = _DiEscortField?.GetValue(form) as FormDiEscort;
             return ss;
         }
     }

--- a/TelegramBotBase/DependencyInjection/Extensions.cs
+++ b/TelegramBotBase/DependencyInjection/Extensions.cs
@@ -63,13 +63,13 @@ namespace TelegramBotBase.DependencyInjection
         }
 
         /// <summary>
-        /// Sets the internal service provider field.
+        /// Sets the internal service scope field.
         /// </summary>
         /// <param name="form"></param>
-        /// <param name="serviceProvider"></param>
-        public static void SetServiceProvider(this FormBase form, IServiceProvider serviceProvider)
+        /// <param name="serviceScope"></param>
+        public static void SetServiceScope(this FormBase form, IServiceScope serviceScope)
         {
-            _ServiceProviderField?.SetValue(form, serviceProvider);
+            _ServiceScopeField?.SetValue(form, serviceScope);
         }
 
         /// <summary>

--- a/TelegramBotBase/DependencyInjection/Extensions.cs
+++ b/TelegramBotBase/DependencyInjection/Extensions.cs
@@ -19,18 +19,7 @@ namespace TelegramBotBase.DependencyInjection
         public static async Task<NewForm> NavigateTo<NewForm>(this FormBase current_form, params object[] args)
             where NewForm : FormBase
         {
-            var _serviceProvider = current_form.GetServiceProvider();
-
-            var instance = ActivatorUtilities.CreateInstance(_serviceProvider, typeof(NewForm)) as NewForm;
-
-            if (instance == null)
-                return null; //throw new Exception("Could not instantiate new form via DI.");
-
-            instance.SetServiceProvider(_serviceProvider);
-
-            await current_form.NavigateTo(instance, args);
-
-            return instance;
+            return await NavigateTo(current_form, typeof(NewForm), args) as NewForm;
         }
 
         /// <summary>
@@ -43,23 +32,19 @@ namespace TelegramBotBase.DependencyInjection
         /// <exception cref="ArgumentException"></exception>
         public static async Task<FormBase> NavigateTo(this FormBase current_form, Type formBaseType, params object[] args)
         {
-            if (!typeof(FormBase).IsAssignableFrom(formBaseType))
-                throw new ArgumentException($"{nameof(formBaseType)} argument must be a {nameof(FormBase)} type");
+            var diEscort = current_form.GetDiEscort();
+            var factory = diEscort.FormFactory;
 
-            var scope = current_form.GetServiceScope();
-
-            var instance = ActivatorUtilities.CreateInstance(_serviceProvider, formBaseType) as FormBase;
-
+            var instance = factory.CreateForm(formBaseType);
+            
             if (instance == null)
                 return null; //throw new Exception("Could not instantiate new form via DI.");
-
-            instance.SetServiceProvider(_serviceProvider);
 
             await current_form.NavigateTo(instance, args);
 
             return instance;
         }
-
+        
         /// <summary>
         /// Sets the internal di escort field.
         /// </summary>

--- a/TelegramBotBase/DependencyInjection/Extensions.cs
+++ b/TelegramBotBase/DependencyInjection/Extensions.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 using TelegramBotBase.Form;
 

--- a/TelegramBotBase/DependencyInjection/FormDiEscort.cs
+++ b/TelegramBotBase/DependencyInjection/FormDiEscort.cs
@@ -14,17 +14,24 @@ public sealed class FormDiEscort : IAsyncDisposable
     {
         FormFactory = null;
 
-        if (ServiceScope == null) return;
+        switch (ServiceScope)
+        {
+            case null:
+            {
+                return;
+            }
+            case IAsyncDisposable ad:
+            {
+                await ad.DisposeAsync();
+                break;
+            }
+            default:
+            {
+                ServiceScope.Dispose();
+                break;
+            }
+        }
 
-        if (ServiceScope is IAsyncDisposable ad)
-        {
-            await ad.DisposeAsync();
-        }
-        else
-        {
-            ServiceScope.Dispose();
-        }
-        
         ServiceScope = null;
     }
 }

--- a/TelegramBotBase/DependencyInjection/FormDiEscort.cs
+++ b/TelegramBotBase/DependencyInjection/FormDiEscort.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using TelegramBotBase.Interfaces;
+
+namespace TelegramBotBase.DependencyInjection;
+
+public sealed class FormDiEscort
+{
+    public IServiceScope ServiceScope;
+    public IFormFactory FormFactory;
+}

--- a/TelegramBotBase/DependencyInjection/FormDiEscort.cs
+++ b/TelegramBotBase/DependencyInjection/FormDiEscort.cs
@@ -1,10 +1,30 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using TelegramBotBase.Interfaces;
 
 namespace TelegramBotBase.DependencyInjection;
 
-public sealed class FormDiEscort
+public sealed class FormDiEscort : IAsyncDisposable
 {
     public IServiceScope ServiceScope;
     public IFormFactory FormFactory;
+    
+    public async ValueTask DisposeAsync()
+    {
+        FormFactory = null;
+
+        if (ServiceScope == null) return;
+
+        if (ServiceScope is IAsyncDisposable ad)
+        {
+            await ad.DisposeAsync();
+        }
+        else
+        {
+            ServiceScope.Dispose();
+        }
+        
+        ServiceScope = null;
+    }
 }

--- a/TelegramBotBase/Factories/DefaultFormFactory.cs
+++ b/TelegramBotBase/Factories/DefaultFormFactory.cs
@@ -40,8 +40,8 @@ public class DefaultFormFactory : IFormFactory
         return form;
     }
 
-    public FormBase CreateForm<T>() where T : FormBase
+    public T CreateForm<T>() where T : FormBase
     {
-        return CreateForm(typeof(T));
+        return (T)CreateForm(typeof(T));
     }
 }

--- a/TelegramBotBase/Factories/LambdaFormFactory.cs
+++ b/TelegramBotBase/Factories/LambdaFormFactory.cs
@@ -28,8 +28,8 @@ public class LambdaFormFactory : IFormFactory
         return _defaultFormFactory.CreateForm(formType);
     }
 
-    public FormBase CreateForm<T>() where T : FormBase
+    public T CreateForm<T>() where T : FormBase
     {
-        return CreateForm(typeof(T));
+        return (T)CreateForm(typeof(T));
     }
 }

--- a/TelegramBotBase/Factories/ServiceProviderFormFactory.cs
+++ b/TelegramBotBase/Factories/ServiceProviderFormFactory.cs
@@ -36,18 +36,20 @@ public class ServiceProviderFormFactory : IFormFactory
         }
 
         FormBase fb = null;
-
+        var scope = _serviceProvider.CreateAsyncScope();
+        var scopeServiceProvider = scope.ServiceProvider;
+        
         try
         {
-            fb = (FormBase)ActivatorUtilities.CreateInstance(_serviceProvider, formType);
+            fb = (FormBase)ActivatorUtilities.CreateInstance(scopeServiceProvider, formType);
         }
         catch(InvalidOperationException ex)
         {
             throw new InvalidServiceProviderConfiguration(ex.Message, ex);
         }
 
-        //Sets an internal field for future ServiceProvider navigation
-        fb.SetServiceProvider(_serviceProvider);
+        //Sets an internal field for dispose scoped dependencies on navigation
+        fb.SetServiceScope(scope);
 
         return fb;
     }

--- a/TelegramBotBase/Factories/ServiceProviderFormFactory.cs
+++ b/TelegramBotBase/Factories/ServiceProviderFormFactory.cs
@@ -52,9 +52,9 @@ public class ServiceProviderFormFactory : IFormFactory
         return fb;
     }
 
-    public FormBase CreateForm<T>() where T : FormBase
+    public T CreateForm<T>() where T : FormBase
     {
-        return CreateForm(typeof(T));
+        return (T)CreateForm(typeof(T));
     }
 }
 

--- a/TelegramBotBase/Factories/ServiceProviderFormFactory.cs
+++ b/TelegramBotBase/Factories/ServiceProviderFormFactory.cs
@@ -50,8 +50,12 @@ public class ServiceProviderFormFactory : IFormFactory
             throw new InvalidServiceProviderConfiguration(ex.Message, ex);
         }
 
-        //Sets an internal field for dispose scoped dependencies on navigation
-        fb.SetServiceScope(scope);
+        //Sets an internal di escort field that used on navigation
+        fb.SetDiEscort(new FormDiEscort
+        {
+            ServiceScope = scope,
+            FormFactory = this
+        });
 
         return fb;
     }

--- a/TelegramBotBase/Factories/ServiceProviderFormFactory.cs
+++ b/TelegramBotBase/Factories/ServiceProviderFormFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using TelegramBotBase.DependencyInjection;
 using TelegramBotBase.Exceptions;
@@ -45,6 +46,7 @@ public class ServiceProviderFormFactory : IFormFactory
         }
         catch(InvalidOperationException ex)
         {
+            Task.Run(async () => await scope.DisposeAsync());
             throw new InvalidServiceProviderConfiguration(ex.Message, ex);
         }
 

--- a/TelegramBotBase/Interfaces/IFormFactory.cs
+++ b/TelegramBotBase/Interfaces/IFormFactory.cs
@@ -7,5 +7,5 @@ public interface IFormFactory
 {
     FormBase CreateStartForm();
     FormBase CreateForm(Type formType);
-    FormBase CreateForm<T>() where T : FormBase;
+    T CreateForm<T>() where T : FormBase;
 }


### PR DESCRIPTION
## Description
This pr fixes #84 by scope creation to each form instance. Scope lifetime correlates with form lifetime: scope dispose on form dispose. Move from `ActivatorUtilities.CreateInstance` usage at di-navigation methods to factory form creation. `FormDiEscort` encapsulate objects that used by di-navigation.